### PR TITLE
Remove Qt slots keyword from non-Q_OBJECT classes

### DIFF
--- a/src/ImageLoaderDialog.h
+++ b/src/ImageLoaderDialog.h
@@ -34,8 +34,6 @@ public:
 	ImageLoaderDialog(ImageLoaderPlugin* imageLoaderPlugin);
 	~ImageLoaderDialog();
 
-private slots:
-
 private:
 	ImageLoaderPlugin*						_imageLoaderPlugin;
 	std::unique_ptr<QVBoxLayout>			_mainLayout;

--- a/src/ImageSequenceWidget.h
+++ b/src/ImageSequenceWidget.h
@@ -18,7 +18,7 @@ public:
 	ImageSequenceWidget(ImageLoaderPlugin* imageLoaderPlugin);
 	~ImageSequenceWidget();
 
-private slots:
+private:
 	void onBecameDirty();
 	void onBeginScan();
 	void onEndScan();

--- a/src/ImageStackWidget.h
+++ b/src/ImageStackWidget.h
@@ -18,7 +18,7 @@ public:
 	ImageStackWidget(ImageLoaderPlugin* imageLoaderPlugin);
 	~ImageStackWidget();
 
-private slots:
+private:
 	void onBecameDirty();
 	void onBeginScan();
 	void onEndScan();


### PR DESCRIPTION
The Qt `slots` keyword is only necessary for member functions that are connected by "old style" (Qt 4) `connect(sender, SIGNAL(...), receiver, SLOT(...))`. The `slots` keyword is not used anymore for modern (Qt 5) connections, `connect(sender, &Sender::valueChanged, receiver, &Receiver::onValueChanged)`. And it does not work for a class that has no `Q_OBJECT`.

See also:
https://wiki.qt.io/New_Signal_Slot_Syntax
https://doc.qt.io/qt-5/signalsandslots.html