### PR TITLE
Add override specifiers to virtual member functions

### DIFF
--- a/src/ImageLoaderDialog.h
+++ b/src/ImageLoaderDialog.h
@@ -17,12 +17,12 @@ class ImageStackWidget;
 
 class StackedWidget : public QStackedWidget
 {
-	QSize sizeHint() const
+	QSize sizeHint() const override
 	{
 		return currentWidget()->sizeHint();
 	}
 
-	QSize minimumSizeHint() const
+	QSize minimumSizeHint() const override
 	{
 		return currentWidget()->minimumSizeHint();
 	}
@@ -32,7 +32,7 @@ class ImageLoaderDialog : public QDialog
 {
 public:
 	ImageLoaderDialog(ImageLoaderPlugin* imageLoaderPlugin);
-	~ImageLoaderDialog();
+	~ImageLoaderDialog() override;
 
 private:
 	ImageLoaderPlugin*						_imageLoaderPlugin;

--- a/src/ImageLoaderPlugin.h
+++ b/src/ImageLoaderPlugin.h
@@ -8,9 +8,9 @@ class ImageLoaderPlugin : public LoaderPlugin
 {
 public:
 	ImageLoaderPlugin() : LoaderPlugin("Image Loader") { }
-    ~ImageLoaderPlugin(void);
+    ~ImageLoaderPlugin(void) override;
     
-    void init();
+    void init() override;
 
     void loadData() Q_DECL_OVERRIDE;
 
@@ -26,7 +26,7 @@ class ImageLoaderPluginFactory : public LoaderPluginFactory
     
 public:
 	ImageLoaderPluginFactory(void) {}
-    ~ImageLoaderPluginFactory(void) {}
+    ~ImageLoaderPluginFactory(void) override {}
     
-	LoaderPlugin* produce();
+	LoaderPlugin* produce() override;
 };

--- a/src/ImageSequence.h
+++ b/src/ImageSequence.h
@@ -13,7 +13,7 @@ class ImageSequence : public QThread
 public:
 	ImageSequence();
 	ImageSequence(const ImageSequence &other);
-	~ImageSequence();
+	~ImageSequence() override;
 
 	enum RunMode
 	{

--- a/src/ImageSequenceWidget.h
+++ b/src/ImageSequenceWidget.h
@@ -16,7 +16,7 @@ class ImageSequenceWidget : public QWidget
 {
 public:
 	ImageSequenceWidget(ImageLoaderPlugin* imageLoaderPlugin);
-	~ImageSequenceWidget();
+	~ImageSequenceWidget() override;
 
 private:
 	void onBecameDirty();

--- a/src/ImageStackWidget.h
+++ b/src/ImageStackWidget.h
@@ -16,7 +16,7 @@ class ImageStackWidget : public QWidget
 {
 public:
 	ImageStackWidget(ImageLoaderPlugin* imageLoaderPlugin);
-	~ImageStackWidget();
+	~ImageStackWidget() override;
 
 private:
 	void onBecameDirty();

--- a/src/ImageStacks.h
+++ b/src/ImageStacks.h
@@ -15,7 +15,7 @@ class ImageStacks : public QThread {
 
 public:
 	ImageStacks();
-	~ImageStacks();
+	~ImageStacks() override;
 
 	QString	directory() const;
 	QStringList	imageTypes() const;


### PR DESCRIPTION
Added `override` specifiers to virtual member functions, according to C++ Core Guidelines, "C.128: Virtual functions should specify exactly one of virtual, override, or final".
https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rh-override

The `override` specifiers were added automatically by Clang Power Tools, Tidy-Fix option `modernize-use-override`:
https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-override.html