### PR TITLE
Remove C-style (type) casts

### DIFF
--- a/src/ImageSequence.cpp
+++ b/src/ImageSequence.cpp
@@ -171,7 +171,7 @@ void ImageSequence::run()
 				loadImage(imageFilePath);
 
 				const auto done			= _imageFilePaths.indexOf(imageFilePath) + 1;
-				const auto percentage	= 100.0f * (done / (float)total);
+				const auto percentage	= 100.0f * (done / static_cast<float>(total));
 				
 				emit message(QString("Loading %1 (%2/%3, %4%)").arg(QFileInfo(imageFilePath).fileName(), QString::number(done), QString::number(total), QString::number(percentage, 'f', 1)));
 			}
@@ -206,9 +206,9 @@ void ImageSequence::loadImage(const QString & imageFilePath)
 		case FIT_BITMAP:
 			if (FreeImage_GetBPP(image) == 8) {
 				for (y = 0; y <  FreeImage_GetHeight(image); y++) {
-					BYTE *bits = (BYTE *)FreeImage_GetScanLine(image, y);
+					BYTE *bits = FreeImage_GetScanLine(image, y);
 					for (x = 0; x <  FreeImage_GetWidth(image); x++) {
-						_pointsData.push_back((float)bits[x]);
+						_pointsData.push_back(static_cast<float>(bits[x]));
 					}
 				}
 			}

--- a/src/ImageStack.cpp
+++ b/src/ImageStack.cpp
@@ -56,7 +56,7 @@ void ImageStack::load()
 	foreach(const QString &imageFilePath, _imageFilePaths) {
 		const auto imageIndex	= _imageFilePaths.indexOf(imageFilePath);
 		const auto done			= imageIndex + 1;
-		const auto percentage	= 100.0f * (done / (float)noImages());
+		const auto percentage	= 100.0f * (done / static_cast<float>(noImages()));
 
 		loadImage(imageFilePath, imageIndex, pointsData);
 
@@ -88,12 +88,12 @@ void ImageStack::loadImage(const QString & imageFilePath, const int& imageIndex,
 		case FIT_BITMAP:
 			if (FreeImage_GetBPP(image) == 8) {
 				for (y = 0; y < imageHeight; y++) {
-					BYTE *bits = (BYTE *)FreeImage_GetScanLine(image, y);
+					BYTE *bits = FreeImage_GetScanLine(image, y);
 					for (x = 0; x < imageWidth; x++) {
 						const auto pixelId = y * imageWidth + x;
 						const auto pointId = (pixelId * noDimensions()) + imageIndex;
 
-						pointsData[pointId] = (float)bits[x];
+						pointsData[pointId] = static_cast<float>(bits[x]);
 					}
 				}
 			}


### PR DESCRIPTION
Removed six C-style casts, replacing them by `static_cast` when necessary (or when desired). Following C++ Core Guidelines, "ES.49: If you must use a cast, use a named cast"
https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es49-if-you-must-use-a-cast-use-a-named-cast

Fixes four VS2017 Code Analysis "warning C26493: Don't use C-style casts". (To my surprise, there was no warning for `(float)noImages()` and `pointsData.push_back((float)bits[x])`.)