### PR TITLE
Fix Code Analysis warnings loadImage (ImageStack, ImageSequence)

### DIFF
--- a/src/ImageSequence.cpp
+++ b/src/ImageSequence.cpp
@@ -196,8 +196,6 @@ void ImageSequence::loadImage(const QString & imageFilePath)
 	
 	auto *image = FreeImage_ConvertToGreyscale(FreeImage_Load(format, imageFilePath.toUtf8()));
 	
-	unsigned x, y;
-
 	const auto image_type = FreeImage_GetImageType(image);
 
 	// qDebug() << image_type;
@@ -205,9 +203,9 @@ void ImageSequence::loadImage(const QString & imageFilePath)
 	switch (image_type) {
 		case FIT_BITMAP:
 			if (FreeImage_GetBPP(image) == 8) {
-				for (y = 0; y <  FreeImage_GetHeight(image); y++) {
-					BYTE *bits = FreeImage_GetScanLine(image, y);
-					for (x = 0; x <  FreeImage_GetWidth(image); x++) {
+				for (unsigned y = 0; y <  FreeImage_GetHeight(image); y++) {
+					const BYTE *const bits = FreeImage_GetScanLine(image, y);
+					for (unsigned x = 0; x <  FreeImage_GetWidth(image); x++) {
 						_pointsData.push_back(static_cast<float>(bits[x]));
 					}
 				}

--- a/src/ImageStack.cpp
+++ b/src/ImageStack.cpp
@@ -76,8 +76,6 @@ void ImageStack::loadImage(const QString & imageFilePath, const int& imageIndex,
 
 	auto* image = FreeImage_ConvertToGreyscale(FreeImage_Load(format, imageFilePath.toUtf8()));
 
-	unsigned x, y;
-
 	const auto image_type	= FreeImage_GetImageType(image);
 	const auto imageWidth	= FreeImage_GetWidth(image);
 	const auto imageHeight	= FreeImage_GetHeight(image);
@@ -87,9 +85,9 @@ void ImageStack::loadImage(const QString & imageFilePath, const int& imageIndex,
 	switch (image_type) {
 		case FIT_BITMAP:
 			if (FreeImage_GetBPP(image) == 8) {
-				for (y = 0; y < imageHeight; y++) {
-					BYTE *bits = FreeImage_GetScanLine(image, y);
-					for (x = 0; x < imageWidth; x++) {
+				for (unsigned y = 0; y < imageHeight; y++) {
+					const BYTE *const bits = FreeImage_GetScanLine(image, y);
+					for (unsigned x = 0; x < imageWidth; x++) {
 						const auto pixelId = y * imageWidth + x;
 						const auto pointId = (pixelId * noDimensions()) + imageIndex;
 


### PR DESCRIPTION
Fixes a few VS2017 Code Analysis warnings from `loadImage` (both in `ImageStack` and `ImageSequence`):

> warning C26462 The value pointed to by 'bits' is assigned only once, mark it as a pointer to const (con.4).
> warning C26494 Variable 'x' is uninitialized. Always initialize an object (type.5).
> warning C26494 Variable 'y' is uninitialized. Always initialize an object (type.5).

To my surprise, warning C26462 only occurred in `ImageSequence`, not in `ImageStack`.