### PR TITLE
Connect currentIndexChanged instead of activated, use new (Qt5) style

### DIFF
--- a/src/ImageLoaderDialog.cpp
+++ b/src/ImageLoaderDialog.cpp
@@ -32,7 +32,8 @@ ImageLoaderDialog::ImageLoaderDialog(ImageLoaderPlugin* imageLoaderPlugin) :
 	_typesComboBox->setItemData(0, "Load in a sequence where each image represents a data point, and the number of dimenions is defined by the number of pixels", Qt::ToolTipRole);
 	_typesComboBox->setItemData(1, "Load in a stack of images where each pixel represents a data point, and each layer represents a dimension", Qt::ToolTipRole);
 
-	connect(_typesComboBox.get(), SIGNAL(activated(int)), _pagesStackedWidget.get(), SLOT(setCurrentIndex(int)));
+	connect(_typesComboBox.get(), QOverload<int>::of(&QComboBox::currentIndexChanged),
+		_pagesStackedWidget.get(), &QStackedWidget::setCurrentIndex);
 
 	_imageSequenceWidget->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 	_imageStackWidget->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);


### PR DESCRIPTION
Connected `_typesComboBox.currentIndexChanged`, instead of `_typesComboBox.activated`, to `pagesStackedWidget.setCurrentIndex`. The `activated` signal is sent "even when the choice is not changed", which appears unnecessary. https://doc.qt.io/qt-5/qcombobox.html#activated

Replaced the old-style Qt SIGNAL/SLOT `connect` by a modern (Qt5) `connect` through member function pointers, which checks at compile time that the member functions match. Avoided ambiguity between the two available `QComboBox::currentIndexChanged` overloads by using `QOverload<int>`.