### PR TITLE
Add missing #include <stdexcept> directives, for std::runtime_error

### DIFF
--- a/src/ImageCollection.cpp
+++ b/src/ImageCollection.cpp
@@ -13,6 +13,7 @@
 #include <QPushButton>
 
 #include <algorithm>
+#include <stdexcept> // For runtime_error.
 
 namespace fi {
 	#include <FreeImage.h>

--- a/src/ImageCollectionScanner.cpp
+++ b/src/ImageCollectionScanner.cpp
@@ -7,6 +7,8 @@
 #include <QMessageBox>
 #include <QProgressDialog>
 
+#include <stdexcept> // For runtime_error.
+
 namespace fi {
 	#include <FreeImage.h>
 }


### PR DESCRIPTION
Fixes compilation errors from Visual C++ 2019, saying
> error C2039: 'runtime_error': is not a member of 'std'