### PR TITLE
Use move semantics to avoid unnecessary data copying

### DIFF
--- a/src/ImageCollection.cpp
+++ b/src/ImageCollection.cpp
@@ -1393,7 +1393,7 @@ bool ImageCollection::load(ImageLoaderPlugin* imageLoaderPlugin)
 
 		auto& points = dynamic_cast<Points&>(imageLoaderPlugin->_core->requestData(datasetName));
 
-		points.setData(std::move(data.data()), static_cast<std::uint32_t>(noPoints), noDimensions);
+		points.setData(std::move(data), noDimensions);
 		points.setDimensionNames(std::vector<QString>(dimensionNames.begin(), dimensionNames.end()));
 
 		points.setProperty("Type", "Images");


### PR DESCRIPTION
Uses the overloaded setData with move semantics