### PR TITLE
Fixes int overflow that stopped loading large images

### DIFF
--- a/src/ImageCollection.cpp
+++ b/src/ImageCollection.cpp
@@ -1466,7 +1466,7 @@ bool ImageCollection::load(ImageLoaderPlugin* imageLoaderPlugin)
         const auto noPoints = this->getNoPoints(Qt::EditRole).toInt();
         const auto noDimensions = this->getNoDimensions(Qt::EditRole).toInt();
 
-        data.resize((unsigned long long) noPoints * noDimensions);
+        data.resize(static_cast<unsigned long long>(noPoints) * noDimensions);
 
         auto imageFilePaths = QStringList();
         auto dimensionNames = QStringList();


### PR DESCRIPTION
When `noPoints * noDimensions` is larger than the max value of whatever type `auto` deduced for `noPoints` the data vector cannot be resized and the image loader does not load the data.

Casting the multiplication to `unsigned long long` should be very future-proof.