### PR TITLE
Fix ci2024 march (#92)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,23 +33,23 @@ jobs:
             build-runtime: MD
             build-config: Release
 
-          - name: Linux_gcc10
+          - name: Linux_gcc11
             os: ubuntu-22.04
             build-cc: gcc
             build-cxx: g++
             build-compiler: gcc
-            build-cversion: 10
+            build-cversion: 11
             build-config: Release
             build-os: Linux
             build-libcxx: libstdc++
 
-          - name: Macos_xcode12.4
-            os: macos-11
+          - name: Macos_xcode13.4
+            os: macos-12
             build-compiler: apple-clang
-            build-cversion: "12.0"
+            build-cversion: 13
             build-config: Release
             build-os: Macos
-            build-xcode-version: 12.4
+            build-xcode-version: 13.4
             build-libcxx: libc++
 
     steps:
@@ -74,7 +74,7 @@ jobs:
       - name: Setup python version
         uses: actions/setup-python@v1
         with:
-          python-version: "3.7"
+          python-version: "3.11"
 
       - name: Start ssh key agent
         uses: webfactory/ssh-agent@v0.5.0

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 cmake-build-debug/
 .vscode
 .vs
+*.bak

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(FREEIMAGE_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/FreeImage CACHE FILEPATH "Path to the directory containing FreeImage .h/.lib/.dll files")
+set(FREEIMAGE_ROOT_DIR "" CACHE FILEPATH "Path to the directory containing FreeImage .h/.lib/.dll files")
 
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
@@ -30,15 +30,9 @@ endif(MSVC)
 # -----------------------------------------------------------------------------
 find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 
+find_package(FreeImage REQUIRED)
 
-find_package(FreeImage QUIET)
-
-if (NOT FREEIMAGE_FOUND)
-    message(FATAL_ERROR "Failed to find FreeImage, not building ImageLoaderPlugin")
-    return()
-else()
-    message(STATUS "FreeImage found at ${FREEIMAGE_INCLUDE_PATH}, ${FREEIMAGE_LIBRARY}")
-endif()
+message(STATUS "FreeImage found at ${FREEIMAGE_INCLUDE_PATH}, ${FREEIMAGE_LIBRARY}, ${FREEIMAGE_LIBRARIES} FREEIMAGE_ROOT_DIR: ${FREEIMAGE_ROOT_DIR}")
 
 # -----------------------------------------------------------------------------
 # Set install directory
@@ -177,32 +171,18 @@ target_link_libraries(${PROJECT} PRIVATE "${FREEIMAGE_LIBRARY}")
 # -----------------------------------------------------------------------------
 # Target installation
 # -----------------------------------------------------------------------------
-if(MSVC)
-    set(FreeImageName "FreeImage")
-elseif(APPLE)
-    set(FreeImageName "freeimage")
-else()
-    set(FreeImageName "freeimage-3.18.0")
-endif()
-
-#file(GET_RUNTIME_DEPENDENCIES
-#    LIBRARIES "${FREEIMAGE_ROOT_DIR}/bin/${CMAKE_SHARED_LIBRARY_PREFIX}${FreeImageName}${CMAKE_SHARED_LIBRARY_SUFFIX}"
-#    RESOLVED_DEPENDENCIES_VAR r_deps
-#    UNRESOLVED_DEPENDENCIES_VAR u_deps) 
-
-#message(STATUS, "Dependencies ${r_deps}")
-
 install(TARGETS ${PROJECT}
     RUNTIME DESTINATION Plugins COMPONENT PLUGINS # Windows .dll
     LIBRARY DESTINATION Plugins COMPONENT PLUGINS # Linux/Mac .so
 )
 
-if(MSVC OR APPLE)
-    # copy the FreeImage library to the root install directory (the same level as the hdps executable)
+set(FreeImageNameShared "${FREEIMAGE_ROOT_DIR}/bin/${CMAKE_SHARED_LIBRARY_PREFIX}FreeImage${CMAKE_SHARED_LIBRARY_SUFFIX}")
+if(EXISTS ${FreeImageNameShared})
+     message(STATUS "Upon install: copy the shared FreeImage library ${FreeImageNameShared} to the root install directory")
     install(FILES
-        "${FREEIMAGE_ROOT_DIR}/bin/${CMAKE_SHARED_LIBRARY_PREFIX}${FreeImageName}${CMAKE_SHARED_LIBRARY_SUFFIX}"
+        ${FreeImageNameShared}
         DESTINATION "${MV_INSTALL_DIR}/$<CONFIGURATION>" COMPONENT IMPORTLIBS
-)
+    )
 endif()
 
 add_custom_command(TARGET ${PROJECT} POST_BUILD

--- a/README.md
+++ b/README.md
@@ -1,36 +1,36 @@
 
-# ImageLoaderPlugin
-Image loader plugin for the HDPS framework
+# ImageLoaderPlugin ![Build Status](https://github.com/ManiVaultStudio/ImageLoaderPlugin/actions/workflows/build.yml/badge.svg?branch=master)
+Image loader plugin for the [ManiVault](https://github.com/ManiVaultStudio/core) framework.
 
-## Local Windows build
-
-Download [FreeImage 3.18.0](https://freeimage.sourceforge.io/download.html) and copy the files to this folder in the following manner for CMAKE to find it automatically:
-```
-├── .
-│   ├── FreeImage
-│   │   ├── bin
-│   │   │   ├── FreeImage.dll
-│   │   ├── include
-│   │   │   ├── FreeImage.h
-│   │   ├── lib
-│   │   │   ├── FreeImage.lib
+```bash
+git clone https://github.com/ManiVaultStudio/ImageLoaderPlugin.git
 ```
 
-## Local Linux build
+## Building
+This project depends on the freeimage library.
 
-Tested with Ubuntu 22.10 and gcc 12.2. 
-Make sure to install some additional dependencies:
+### Windows
+Using a package manager: install freeimage with vcpkg or conan and specify the cmake toolchain accordingly.
+
+Manual:
+Download [FreeImage 3.18.0](https://freeimage.sourceforge.io/download.html), copy the files to this folder in the following manner, and define the cmake path variable `FREEIMAGE_ROOT_DIR` to `./FreeImage`:
+```
+.
+├── FreeImage
+│   ├── bin
+│   │   ├── FreeImage.dll
+│   ├── include
+│   │   ├── FreeImage.h
+│   ├── lib
+│   │   ├── FreeImage.lib
+```
+
+### Linux
 ```
 apt install qt6-image-formats-plugins libfreeimage-dev
 ```
 
-## CI-CD
-
-Pushing to the hdps/ImageLoaderPlugin develop will trigger the conan CI_CD to start a build via the configured Webhook.
-
-Currently the following build matrix is performed
-
-OS | Architecture | Compiler
---- | --- | ---
-Windows | x64 | MSVC 2019
-Macos | x86_64 | clang 12
+### Mac
+```
+brew install freeimage
+```


### PR DESCRIPTION
* Update workflow

* Change some hdps references to manivault

* Use conan center for freeimage

* try no defaults

* Only remove linux fPIC option

* Test options

* Does not work

* Another fix

* Try defaults again

* But not that many defaults

* Add libtiff

* Step by step

* fPIC false

* Forgotten defaults

* More specific

* More options

* Specify all the versions

* Shared

* more

* smaller libdeflate version

* libtiff cppstd = 17

* compiler.cppstd

* compiler.cppstd = "17"

* Remove

* Just use sudo

* Less conan index

* Only set freeimage dir on windows

* cmake: free image is required

* Only install freeimage on windows

* No default freeimage dir

* Re-enable automatic freeimage find on windows

* Less custom code

* Two ways of finding freeimage

* One way

* Copy link and install

* Go back to artifactory freeimage for windows

* Add some more install instructions to readme