### PR TITLE
Add unity build option 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.12.0)
 
+option(MV_UNITY_BUILD "Combine target source files into batches for faster compilation" OFF)
+
 # -----------------------------------------------------------------------------
 # ImageLoader Plugin
 # -----------------------------------------------------------------------------
@@ -131,9 +133,6 @@ QT6_WRAP_UI(UI_HEADERS ${UIS})
 # -----------------------------------------------------------------------------
 add_library(${PROJECT} SHARED ${SOURCES} ${UIS} ${AUX})
 
-qt_wrap_cpp(IMAGELOADER_MOC ${PLUGIN_MOC_HEADERS} TARGET ${PROJECT})
-target_sources(${PROJECT} PRIVATE ${IMAGELOADER_MOC})
-
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
@@ -148,6 +147,10 @@ target_compile_features(${PROJECT} PRIVATE cxx_std_17)
 
 add_definitions(-DDISABLE_PERF_MEASUREMENT)
  
+if(MV_UNITY_BUILD)
+    set_target_properties(${PROJECT} PROPERTIES UNITY_BUILD ON)
+endif()
+
 # -----------------------------------------------------------------------------
 # Target library linking
 # -----------------------------------------------------------------------------

--- a/conanfile.py
+++ b/conanfile.py
@@ -120,6 +120,9 @@ class ImageLoaderPluginConan(ConanFile):
         self.install_dir = pathlib.Path(os.environ["MV_INSTALL_DIR"]).as_posix()
         # Give the installation directory to CMake
         tc.variables["MV_INSTALL_DIR"] = self.install_dir
+
+        # Set some build options
+        tc.variables["MV_UNITY_BUILD"] = "ON"
         
         # Use try except to help debugging
         try:


### PR DESCRIPTION
Adds optional [unity build](https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html): `OFF` by default, except on CI where it's `ON`.