### PR TITLE
Warn on image load failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ git clone https://github.com/ManiVaultStudio/ImageLoaderPlugin.git
   - Create a image pyramid of user-defined size by downsampling the image on every level 
 
 ## Building
-This project depends on the [freeimage](https://freeimage.sourceforge.io/) library. Ensure that CMake can find freeimage during configuration. 
+This plugin depends on the [FreeImage ](https://freeimage.sourceforge.io/) library. Ensure that CMake can find FreeImage  during configuration. 
+
+The Image Loader can also make use of the `Qt Imaging Formats` plugin to support more than the [standard QT image formats](https://doc.qt.io/qt-6/qimagereader.html#supportedImageFormats) like [TIFF files](https://en.wikipedia.org/wiki/TIFF) and [WebP](https://en.wikipedia.org/wiki/WebP).
 
 ### Windows
 Using a package manager: install freeimage with [vcpkg](https://github.com/microsoft/vcpkg/) or [conan](https://conan.io/) and specify the [cmake toolchain](https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html) accordingly.
@@ -47,9 +49,11 @@ Download [FreeImage 3.18.0](https://freeimage.sourceforge.io/download.html), arr
 │   │   ├── FreeImage.lib
 ```
 
+When installing Qt6, make sure to also install the additional library `Qt Imaging Formats`.
+
 ### Linux
 ```
-apt install qt6-image-formats-plugins libfreeimage-dev
+sudo apt install qt6-image-formats-plugins libfreeimage-dev
 ```
 
 ### Mac

--- a/src/ImageCollection.cpp
+++ b/src/ImageCollection.cpp
@@ -218,7 +218,7 @@ void ImageCollection::Image::load(std::vector<float>& data, const std::uint32_t&
         {
             handleException(e.what());
         }
-        catch (std::exception e)
+        catch (const std::exception& e)
         {
             handleException(e.what());
         }
@@ -578,7 +578,7 @@ void ImageCollection::Image::loadBitmap(FI::FIBITMAP* bitmap, std::vector<float>
     {
         handleException(e.what());
     }
-    catch (std::exception e)
+    catch (const std::exception& e)
     {
         handleException(e.what());
     }
@@ -600,7 +600,6 @@ QString ImageCollection::Image::guessDimensionName()
             FI::FIMULTIBITMAP* multiBitmap = nullptr;
 
             const auto fileNameUtf8 = _filePath.toUtf8();
-            const auto format = FI::FreeImage_GetFileType(fileNameUtf8);
 
             multiBitmap = FI::FreeImage_OpenMultiBitmap(FI::FIF_TIFF, fileNameUtf8, false, false, false);
 
@@ -643,7 +642,7 @@ QString ImageCollection::Image::guessDimensionName()
     {
         throw e;
     }
-    catch (std::exception e)
+    catch (const std::exception& e)
     {
         throw e;
     }
@@ -1696,7 +1695,7 @@ QStringList ImageCollection::guessDimensionNames()
         QMessageBox::critical(nullptr, QString("Unable to guess dimensions names for %1").arg(_name), e.what());
         return QStringList();
     }
-    catch (std::exception e)
+    catch (const std::exception& e)
     {
         QMessageBox::critical(nullptr, QString("Unable to guess dimensions names for %1").arg(_name), e.what());
         return QStringList();
@@ -1825,7 +1824,7 @@ Dataset<DatasetImpl> ImageCollection::load(ImageLoaderPlugin* imageLoaderPlugin,
     {
         QMessageBox::critical(nullptr, QString("Unable to load %1").arg(_name), e.what());
     }
-    catch (std::exception e)
+    catch (const std::exception& e)
     {
         QMessageBox::critical(nullptr, QString("Unable to load %1").arg(_name), e.what());
     }

--- a/src/ImageCollection.cpp
+++ b/src/ImageCollection.cpp
@@ -182,7 +182,7 @@ void ImageCollection::Image::setPageIndex(const std::int32_t& pageIndex)
     _pageIndex = pageIndex;
 }
 
-void ImageCollection::Image::load(ImageLoaderPlugin* imageLoaderPlugin, std::vector<float>& data, const std::uint32_t& imageIndex, QStringList& dimensionNames, FI::FIMULTIBITMAP* multiBitmap /*= nullptr*/)
+void ImageCollection::Image::load(std::vector<float>& data, const std::uint32_t& imageIndex, QStringList& dimensionNames, FI::FIMULTIBITMAP* multiBitmap /*= nullptr*/)
 {
     qDebug() << QString("Loading image: %1").arg(_fileName);
 
@@ -269,7 +269,6 @@ template<class T> static void readSequence(ImageCollection* imageCollection, FI:
     const auto targetWidth	= targetSize.width();
     const auto targetHeight = targetSize.height();
     const auto noPixels		= targetWidth * targetHeight;
-    const auto grayscale	= imageCollection->getToGrayscale(Qt::EditRole).toBool();
 
     for (std::int32_t y = 0; y < targetHeight; y++) {
         auto scanLine = reinterpret_cast<T*>(FI::FreeImage_GetScanLine(bitmap, y));
@@ -311,7 +310,6 @@ static void readStack(ImageCollection* imageCollection, FI::FIBITMAP* bitmap, st
     const auto targetSize	= imageCollection->getTargetSize(Qt::EditRole).toSize();
     const auto targetWidth	= targetSize.width();
     const auto targetHeight = targetSize.height();
-    const auto noPixels		= targetWidth * targetHeight;
     const auto grayscale	= imageCollection->getToGrayscale(Qt::EditRole).toBool();
 	const auto imageType	= FI::FreeImage_GetImageType(bitmap);
 	const auto isBitmap		= imageType == FI::FIT_BITMAP;
@@ -662,7 +660,7 @@ ImageCollection* ImageCollection::Image::getImageCollection()
     return static_cast<ImageCollection*>(getParentItem());
 }
 
-ImageCollection::SubSampling::SubSampling(ImageCollection* imageCollection, const bool& enabled /*= false*/, const float& ratio /*= 0.5f*/, const Filter& filter /*= ImageResamplingFilter::Bicubic*/) :
+ImageCollection::SubSampling::SubSampling(ImageCollection* imageCollection, const float& ratio /*= 0.5f*/, const Filter& filter /*= ImageResamplingFilter::Bicubic*/) :
     _imageCollection(imageCollection),
     _type(Type::Resample),
     _ratio(ratio),
@@ -1742,7 +1740,6 @@ Dataset<DatasetImpl> ImageCollection::load(ImageLoaderPlugin* imageLoaderPlugin,
 
         if (multiPageTiff) {
             const auto fileNameUtf8 = firstChild->getFilePath(Qt::EditRole).toString().toUtf8();
-            const auto format = FI::FreeImage_GetFileType(fileNameUtf8);
 
             multiBitmap = FI::FreeImage_OpenMultiBitmap(FI::FIF_TIFF, fileNameUtf8, false, false, false);
 
@@ -1769,7 +1766,7 @@ Dataset<DatasetImpl> ImageCollection::load(ImageLoaderPlugin* imageLoaderPlugin,
                 if (!image->getShouldLoad(Qt::EditRole).toBool())
                     continue;
 
-                image->load(imageLoaderPlugin, data, imageIndex, dimensionNames, multiBitmap);
+                image->load(data, imageIndex, dimensionNames, multiBitmap);
 
                 imageIndex++;
 
@@ -1841,8 +1838,6 @@ Dataset<DatasetImpl> ImageCollection::load(ImageLoaderPlugin* imageLoaderPlugin,
 
 bool ImageCollection::containsNans(std::vector<float>& data)
 {
-    auto containsNans = false;
-
     for (auto element : data)
         if (std::isnan(element))
             return true;

--- a/src/ImageCollection.cpp
+++ b/src/ImageCollection.cpp
@@ -381,11 +381,12 @@ void ImageCollection::Image::loadBitmap(FI::FIBITMAP* bitmap, std::vector<float>
         const auto imageCollectionType	= static_cast<ImageData::Type>(getImageCollection()->getType(Qt::EditRole).toInt());
         const auto sourceWidth			= FI::FreeImage_GetWidth(bitmap);
         const auto sourceHeight			= FI::FreeImage_GetHeight(bitmap);
+        const auto sourceSize           = QSize(static_cast<int>(sourceWidth), static_cast<int>(sourceHeight));
         const auto targetSize			= getImageCollection()->getTargetSize(Qt::EditRole).toSize();
         const auto targetWidth			= targetSize.width();
         const auto targetHeight			= targetSize.height();
         const auto noDimensions			= getImageCollection()->getNoDimensions(Qt::EditRole).toInt();
-        const auto subsample			= QSize(sourceWidth, sourceHeight) != targetSize;
+        const auto subsample			= (targetWidth >= 0 && targetHeight >= 0) && sourceSize != targetSize;
         const auto filter				= static_cast<FI::FREE_IMAGE_FILTER>(getImageCollection()->getSubsampling().getFilter(Qt::EditRole).toInt());
 
         subsampledBitmap = subsample ? FI::FreeImage_Rescale(bitmap, targetWidth, targetHeight, filter) : bitmap;

--- a/src/ImageCollection.h
+++ b/src/ImageCollection.h
@@ -161,13 +161,12 @@ public: // Nested image class
 
         /**
          * Loads the image into a high-dimensional data vector
-         * @param imageLoaderPlugin Pointer to image loader plugin
          * @param data High-dimensional data vector
          * @param imageIndex Image index
          * @param dimensionNames Dimension names
          * @param multiBitmap Multi-bitmap in case of multi-page TIFF
          */
-        void load(ImageLoaderPlugin* imageLoaderPlugin, std::vector<float>& data, const std::uint32_t& imageIndex, QStringList& dimensionNames, FI::FIMULTIBITMAP* multiBitmap = nullptr);
+        void load(std::vector<float>& data, const std::uint32_t& imageIndex, QStringList& dimensionNames, FI::FIMULTIBITMAP* multiBitmap = nullptr);
 
         /**
          * Loads the image bitmap into a high-dimensional data vector
@@ -243,11 +242,10 @@ public: // Nested image class
         /**
          * Constructor
          * @param imageCollection Image collection
-         * @param enabled Whether subsampling is enabled
          * @param ratio The subsampling ratio
          * @param filter The subsampling filter
          */
-        SubSampling(ImageCollection* imageCollection, const bool& enabled = false, const float& ratio = 0.5f, const Filter& filter = Filter::Bicubic);
+        SubSampling(ImageCollection* imageCollection, const float& ratio = 0.5f, const Filter& filter = Filter::Bicubic);
 
     public: // Getters/setters
 
@@ -265,19 +263,6 @@ public: // Nested image class
         void setType(const Type& type);
 
         /**
-         * Returns whether subsampling is enabled
-         * @param role Data role
-         * @return Whether subsampling is enabled in variant form
-         */
-        QVariant getEnabled(const int& role) const;
-
-        /**
-         * Sets whether subsampling is enabled
-         * @param enabled Whether subsampling is enabled
-         */
-        void setEnabled(const bool& enabled);
-
-        /**
          * Returns the subsampling ratio
          * @param role Data role
          * @return The subsampling ratio in variant form
@@ -286,7 +271,7 @@ public: // Nested image class
 
         /**
          * Sets the subsampling ratio
-         * @param enabled The subsampling ratio
+         * @param ratio The subsampling ratio
          */
         void setRatio(const float& ratio);
 

--- a/src/ImageCollection.h
+++ b/src/ImageCollection.h
@@ -14,11 +14,9 @@
 #include <QImage>
 
 namespace FI {
-
-#pragma warning(disable: 4828)
-
+#pragma warning(disable:4828)   // The file contains a character starting at offsetthat is illegal in the current source character set
 #include <FreeImage.h>
-
+#pragma warning(default:4828)
 }
 
 class ImageLoaderPlugin;

--- a/src/ImageCollectionScanner.cpp
+++ b/src/ImageCollectionScanner.cpp
@@ -291,18 +291,15 @@ void ImageCollectionScanner::scanDir(const QString& directory, QStringList nameF
 
         if (!imageReader.canRead())
         {
-            if (!imageReader.canRead())
-            {
-                qWarning() << "ImageLoaderPlugin: cannot read file " << fileName;
+            qWarning() << "ImageLoaderPlugin: cannot read file " << fileName;
 
-                QStringList supportedImageFormats;
-                for (const QByteArray& byteArray : QImageReader::supportedImageFormats()) {
-                    supportedImageFormats.append(QString(byteArray));  // Convert QByteArray to QString
-                }
-
-                qWarning() << "ImageLoaderPlugin: supported image formats: " << supportedImageFormats.join(", ");
-                qWarning() << "ImageLoaderPlugin: consider installing the Qt Imaging Formats plugin to support formates like tiff and webp.";
+            QStringList supportedImageFormats;
+            for (const QByteArray& byteArray : QImageReader::supportedImageFormats()) {
+                supportedImageFormats.append(QString(byteArray));  // Convert QByteArray to QString
             }
+
+            qWarning() << "ImageLoaderPlugin: supported image formats: " << supportedImageFormats.join(", ");
+            qWarning() << "ImageLoaderPlugin: consider installing the Qt Imaging Formats plugin to support formates like tiff and webp.";
         }
 
         auto imageExtension = QFileInfo(fileName).suffix().toUpper();

--- a/src/ImageCollectionScanner.cpp
+++ b/src/ImageCollectionScanner.cpp
@@ -287,6 +287,22 @@ void ImageCollectionScanner::scanDir(const QString& directory, QStringList nameF
 
         QImageReader imageReader(imageFilePath);
 
+        if (!imageReader.canRead())
+        {
+            if (!imageReader.canRead())
+            {
+                qWarning() << "ImageLoaderPlugin: cannot read file " << fileName;
+
+                QStringList supportedImageFormats;
+                for (const QByteArray& byteArray : QImageReader::supportedImageFormats()) {
+                    supportedImageFormats.append(QString(byteArray));  // Convert QByteArray to QString
+                }
+
+                qWarning() << "ImageLoaderPlugin: supported image formats: " << supportedImageFormats.join(", ");
+                qWarning() << "ImageLoaderPlugin: consider installing the Qt Imaging Formats plugin to support formates like tiff and webp.";
+            }
+        }
+
         auto imageExtension = QFileInfo(fileName).suffix().toUpper();
         auto pageCount = 0;
 

--- a/src/ImageCollectionScanner.cpp
+++ b/src/ImageCollectionScanner.cpp
@@ -201,7 +201,7 @@ void ImageCollectionScanner::scan()
     {
         QMessageBox::critical(nullptr, QString("Unable to scan %1").arg(_directory), e.what());
     }
-    catch (std::exception e)
+    catch (const std::exception& e)
     {
         QMessageBox::critical(nullptr, QString("Unable to scan %1").arg(_directory), e.what());
     }

--- a/src/ImageCollectionScanner.cpp
+++ b/src/ImageCollectionScanner.cpp
@@ -4,10 +4,12 @@
 
 #include <BackgroundTask.h>
 
+#include <QByteArray>
 #include <QDebug>
 #include <QDir>
 #include <QImageReader>
 #include <QMessageBox>
+#include <QStringList>
 #include <QSysInfo>
 
 #include <stdexcept>


### PR DESCRIPTION
When the `Qt Imaging Formats` plugin is not installed, some images like `tiff` files cannot be loaded. They will be listed with width, height and number of points as -1 which does indicate that something is not right.

With this PR, `ImageCollectionScanner::scanDir()` additionally emits some debug info when scanned images cannot be read. I also added some more information on installing `Qt Imaging Formats` to the README. 

As far as I can see, there is no straightforward way of checking if the `Qt Imaging Formats` plugin is available during build time on all OSs that we want to support, so the docs will have to do...

Also:
-  remove some unused variables
- capture exceptions as references