### PR TITLE
Default to Home on linux

### DIFF
--- a/src/ImageCollectionScanner.cpp
+++ b/src/ImageCollectionScanner.cpp
@@ -44,7 +44,7 @@ ImageCollectionScanner::~ImageCollectionScanner()
 
 void ImageCollectionScanner::loadSettings()
 {
-    const auto directory = _imageLoaderPlugin.getSetting("Scanner/Directory", QSysInfo::productType() == QString("macos") ? QDir::homePath() : "").toString();
+    const auto directory = _imageLoaderPlugin.getSetting("Scanner/Directory", QSysInfo::productType() != QString("windows") ? QDir::homePath() : "").toString();
 
     setDirectory(QDir(directory).exists() ? directory : QDir::homePath(), true);
     setSeparateByDirectory(_imageLoaderPlugin.getSetting("Scanner/SeparateByDirectory", true).toBool());


### PR DESCRIPTION
When first opening the image loader on linux, the default search directory for images is "", which is probably not what we want.
We should default to HOME, like on macos.

See [QSysInfo::productType](https://doc.qt.io/qt-6/qsysinfo.html#productType): this will be "windows" on Windows