### PR TITLE
Enforce CXX14 In FreeImage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ find_package(ManiVault COMPONENTS Core PointData ImageData CONFIG)
 FetchContent_Declare(
     FreeImage
     GIT_REPOSITORY https://github.com/biovault/FreeImage
-    GIT_TAG c5586983279b5901fbd868bb1582f7427d6e6765    # master as of 12-11-2024, version 3.18.0 with cmake files
+    GIT_TAG ca81f5cdf221fd55e0f066119babe24a59cec518    # master as of 19-11-2024, version 3.18.0 with cmake files
     GIT_SHALLOW TRUE
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ find_package(ManiVault COMPONENTS Core PointData ImageData CONFIG)
 FetchContent_Declare(
     FreeImage
     GIT_REPOSITORY https://github.com/biovault/FreeImage
-    GIT_TAG 7605c3f71aea57be61be3db73227b5baa445dbb7    # master as of 19-11-2024, version 3.18.0 with cmake files
+    GIT_TAG 2fcb6ca6d3d4dd36f7be82368275dcce918227fa    # master as of 19-11-2024, version 3.18.0 with cmake files
     GIT_SHALLOW TRUE
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ find_package(ManiVault COMPONENTS Core PointData ImageData CONFIG)
 FetchContent_Declare(
     FreeImage
     GIT_REPOSITORY https://github.com/biovault/FreeImage
-    GIT_TAG ca81f5cdf221fd55e0f066119babe24a59cec518    # master as of 19-11-2024, version 3.18.0 with cmake files
+    GIT_TAG 7605c3f71aea57be61be3db73227b5baa445dbb7    # master as of 19-11-2024, version 3.18.0 with cmake files
     GIT_SHALLOW TRUE
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ set_target_properties(FreeImageLib PROPERTIES EXCLUDE_FROM_ALL ON)
 if(MSVC)
     target_compile_options(OpenEXR PRIVATE /permissive)
     target_compile_options(FreeImage PRIVATE /permissive)
+    target_compile_options(FreeImageLib PRIVATE /permissive) # we don't need the static library, but just in case someone does build it
 endif(MSVC)
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
We `set(CMAKE_C_STANDARD 17)` in the core and when building this repo in the dev bundle that overrides the cxx14 standard suggested in freeimage. 

- Updated freeimage to enforce cxx14 for itself regardless of the standard set for consuming projects, see https://github.com/biovault/FreeImage/pull/4 and https://github.com/biovault/FreeImage/pull/5
- Also set `permissive` for static `FreeImageLib`. We do not use this library, but a build might be triggered in a Visual Studio project and would fail.