### PR TITLE
OME TIFF channel names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ set(PLUGIN_SOURCES
     src/ImageCollectionsModel.h
     src/ImageCollectionsModel.cpp
     src/Common.h
+    src/OmeHelper.h
 )
 
 set(PLUGIN_MOC_HEADERS

--- a/src/DimensionTagAction.cpp
+++ b/src/DimensionTagAction.cpp
@@ -5,12 +5,14 @@
 
 const QMap<DimensionTagAction::DefaultTag, TriggersAction::Trigger> DimensionTagAction::triggers = QMap<DimensionTagAction::DefaultTag, TriggersAction::Trigger>({
     { DimensionTagAction::PageName, TriggersAction::Trigger("PageName", "PageName TIFF tag") },
-    { DimensionTagAction::ImageDescription, TriggersAction::Trigger("ImageDescription", "ImageDescription TIFF tag") }
+    { DimensionTagAction::ImageDescription, TriggersAction::Trigger("ImageDescription", "ImageDescription TIFF tag") },
+    { DimensionTagAction::ImageDescriptionOME, TriggersAction::Trigger("OME TIFF", "ImageDescription for OME TIFF tag") }
     });
 
 const QMap<DimensionTagAction::DefaultTag, QString> DimensionTagAction::defaultTags = QMap<DimensionTagAction::DefaultTag, QString>({
     { DimensionTagAction::PageName, "PageName"},
-    { DimensionTagAction::ImageDescription, "ImageDescription"}
+    { DimensionTagAction::ImageDescription, "ImageDescription"},
+    { DimensionTagAction::ImageDescriptionOME, "OME TIFF"}
 });
 
 DimensionTagAction::DimensionTagAction(QObject* parent, ImageLoaderPlugin& imageLoaderPlugin) :

--- a/src/DimensionTagAction.h
+++ b/src/DimensionTagAction.h
@@ -17,7 +17,8 @@ public:
 
     enum DefaultTag {
         PageName,
-        ImageDescription
+        ImageDescription,
+        ImageDescriptionOME
     };
 
     static const QMap<DefaultTag, TriggersAction::Trigger> triggers;

--- a/src/ImageCollection.cpp
+++ b/src/ImageCollection.cpp
@@ -649,7 +649,7 @@ QString ImageCollection::Image::guessDimensionName()
                     }
                 }
                 
-                if(_pageIndex <= _omeDimNames.size())
+                if(!_omeDimNames.empty() && _pageIndex <= _omeDimNames.size())
                     dimensionName = _omeDimNames[_pageIndex];
 
             }

--- a/src/ImageCollection.cpp
+++ b/src/ImageCollection.cpp
@@ -1,7 +1,9 @@
 #include "ImageCollection.h"
+
 #include "ImageLoaderPlugin.h"
+#include "OmeHelper.h"
 #include "SanitizeDataDialog.h"
-#include "Common.h"
+
 #include "Dataset.h"
 #include "util/Miscellaneous.h"
 
@@ -14,6 +16,7 @@
 #include <QMessageBox>
 #include <QProgressDialog>
 #include <QCoreApplication>
+#include <QPointer>
 #include <QPushButton>
 #include <QtGlobal>
 #include <QDir>
@@ -21,6 +24,7 @@
 #include <algorithm>
 #include <cmath>
 #include <stdexcept>
+#include <string>
 
 namespace fi {
 #include <FreeImage.h>
@@ -43,6 +47,8 @@ const QMap<ImageCollection::SubSampling::Filter, QString> ImageCollection::SubSa
     { ImageCollection::SubSampling::Filter::CatmullRom, "Catmull-Rom"},
     { ImageCollection::SubSampling::Filter::Lanczos, "Lanczos"}
 });
+
+std::vector<QString> ImageCollection::Image::_omeDimNames = {};
 
 ImageCollection::Image::Image(TreeItem* parent, const QString& filePath, const std::int32_t& pageIndex /*= -1*/) :
     TreeItem(parent),
@@ -615,7 +621,39 @@ QString ImageCollection::Image::guessDimensionName()
 
             QString dimensionName;
 
-            if (!dimensionTag.isEmpty()) {
+            if (dimensionTag.isEmpty())
+                qWarning() << "ImageLoader: dimensionTag is empty";
+            else if (dimensionTag == "OME TIFF") {
+
+                // OME TIFFS come with one XML stored in the ImageDescription tag of the first page
+                // https://docs.openmicroscopy.org/ome-model/5.5.7/ome-tiff/specification.html
+                if (_pageIndex == 0) {
+                    _omeDimNames.clear();
+
+                    FI::FITAG* tag = nullptr;
+
+                    FI::FreeImage_GetMetadata(FI::FIMD_EXIF_MAIN, pageBitmap, "ImageDescription", &tag);
+
+                    if (tag != nullptr) {
+                        const char* cstr = reinterpret_cast<const char*>(FI::FreeImage_GetTagValue(tag));
+                        std::string OME_XML(cstr);
+
+                        const bool isValidOME = validateXMLandOME(OME_XML);
+
+                        if (isValidOME) {
+                            std::vector<std::string> channelEntries = extractChannels(OME_XML);
+
+                            for (const auto& channel : channelEntries)
+                                _omeDimNames.push_back(QString::fromStdString(extractChannelName(channel)));
+                        }
+                    }
+                }
+                
+                if(_pageIndex <= _omeDimNames.size())
+                    dimensionName = _omeDimNames[_pageIndex];
+
+            }
+            else {
                 FI::FITAG* tag = nullptr;
 
                 FI::FreeImage_GetMetadata(FI::FIMD_EXIF_MAIN, pageBitmap, dimensionTag.toLatin1(), &tag);

--- a/src/ImageCollection.h
+++ b/src/ImageCollection.h
@@ -13,6 +13,8 @@
 #include <QVector>
 #include <QImage>
 
+#include <vector>
+
 namespace FI {
 #pragma warning(disable:4828)   // The file contains a character starting at offsetthat is illegal in the current source character set
 #include <FreeImage.h>
@@ -204,6 +206,9 @@ public: // Nested image class
         QString         _dimensionName;                 /** Dimension name (in case of image stack) */
         bool            _shouldLoad;                    /** Whether the image should be loaded */
         std::int32_t    _pageIndex;                     /** Page index (in case of multi-page TIFF) */
+
+    private:
+        static std::vector<QString> _omeDimNames;    /** Helper object to store all dimension names (in case of multi-page TIFF) */
     };
 
     /**

--- a/src/OmeHelper.h
+++ b/src/OmeHelper.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+// Just checks if the string starts with XML and contains an OME field
+inline static bool validateXMLandOME(const std::string& xml) {
+    // Check if the string begins with "<?xml"
+    if (xml.size() < 5 || xml.substr(0, 5) != "<?xml") {
+        return false;
+    }
+
+    // Check if it contains an "OME" tag
+    if (xml.find("<OME") == std::string::npos) {
+        return false;
+    }
+
+    return true;
+}
+
+// Assumes that each channel XML field starts with "Channel"
+inline static std::vector<std::string> extractChannels(const std::string& xml) {
+    std::vector<std::string> channels;
+
+    // Method 1: Using string operations (more efficient for simple cases)
+    size_t pos = 0;
+    while (true) {
+        // Find the start of a Channel tag
+        size_t startPos = xml.find("<Channel", pos);
+        if (startPos == std::string::npos) {
+            break;
+        }
+
+        // Find the end of the Channel tag (looking for />)
+        size_t endPos = xml.find("/>", startPos);
+        if (endPos == std::string::npos) {
+            break;
+        }
+
+        // Extract the complete channel tag
+        std::string channelTag = xml.substr(startPos, endPos - startPos + 2);
+        channels.push_back(channelTag);
+
+        // Move past this channel to find the next one
+        pos = endPos + 2;
+    }
+
+    return channels;
+}
+
+// Assumes that the name is stored in a "Name" field
+inline static std::string extractChannelName(const std::string& channelEntry) {
+    // Look for the Name attribute
+    size_t namePos = channelEntry.find("Name=\"");
+    if (namePos == std::string::npos) {
+        return ""; // Name attribute not found
+    }
+
+    // Move position to the start of the name value (after Name=")
+    namePos += 6; // 6 is the length of 'Name="'
+
+    // Find the closing quote
+    size_t nameEndPos = channelEntry.find("\"", namePos);
+    if (nameEndPos == std::string::npos) {
+        return ""; // Closing quote not found (malformed XML)
+    }
+
+    // Extract and return the name
+    return channelEntry.substr(namePos, nameEndPos - namePos);
+}


### PR DESCRIPTION
Add option for trying to load image names from [OME TIFFs](https://docs.openmicroscopy.org/ome-model/5.5.7/ome-tiff/specification.html).

OME TIFFs are multi-page tiffs and come with a XML-formatted text stored in the ImageDescription tag of the first page.
For each channel they have an entry in that "header".