### PR TITLE
Update to Freeimage 3.19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,12 +17,12 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if(MSVC)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /MD")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
-endif(MSVC)
+endif()
 
 # -----------------------------------------------------------------------------
 # Dependencies
@@ -56,11 +56,11 @@ else()
     set_target_properties(FreeImageLib PROPERTIES EXCLUDE_FROM_ALL ON)
 
     # Remove /permissive- for OpenEXR and FreeImage
-    if(MSVC)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         target_compile_options(OpenEXR PRIVATE /permissive)
         target_compile_options(FreeImage PRIVATE /permissive)
         target_compile_options(FreeImageLib PRIVATE /permissive) # we don't need the static library, but just in case someone does build it
-    endif(MSVC)
+    endif()
 endif()
 
 # -----------------------------------------------------------------------------
@@ -209,7 +209,7 @@ set_target_properties(${PROJECT}
 # Miscellaneous
 # -----------------------------------------------------------------------------
 # Automatically set the debug environment (command + working directory) for MSVC
-if(MSVC)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set_property(TARGET ${PROJECT} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<IF:$<CONFIG:DEBUG>,${ManiVault_INSTALL_DIR}/Debug,$<IF:$<CONFIG:RELWITHDEBINFO>,${ManiVault_INSTALL_DIR}/RelWithDebInfo,${ManiVault_INSTALL_DIR}/Release>>)
     set_property(TARGET ${PROJECT} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,"${ManiVault_INSTALL_DIR}/Debug/ManiVault Studio.exe",$<IF:$<CONFIG:RELWITHDEBINFO>,"${ManiVault_INSTALL_DIR}/RelWithDebInfo/ManiVault Studio.exe","${ManiVault_INSTALL_DIR}/Release/ManiVault Studio.exe">>)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,10 +34,13 @@ find_package(ManiVault COMPONENTS Core PointData ImageData CONFIG QUIET)
 FetchContent_Declare(
     FreeImage
     GIT_REPOSITORY https://github.com/biovault/FreeImage
-    GIT_TAG 2fcb6ca6d3d4dd36f7be82368275dcce918227fa    # master as of 19-11-2024, version 3.18.0 with cmake files
+    GIT_TAG db0f4151dd45a7bf98b9dfe9bd81190b523076dd    # version 3.19.0 with cmake files
 )
 
 FetchContent_MakeAvailable(FreeImage)
+
+get_target_property(FreeImageVersion FreeImageLib VERSION)
+message(STATUS "FreeImage Version: ${FreeImageVersion}")
 
 set_target_properties(FreeImage FreeImageLib LibJPEG LibJXR LibOpenJPEG LibPNG LibRaw LibTIFF4 LibWebP OpenEXR ZLibFreeImage 
     PROPERTIES 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ else()
     FetchContent_Declare(
         FreeImage
         GIT_REPOSITORY https://github.com/biovault/FreeImage
-        GIT_TAG 4532197864740ae6dc8331f7d956c0b4dbd7029c        # version 3.19.0.1, freeimage + cmake files + some updated modules
+        GIT_TAG v3.19.0 # version 3.19.0.1, freeimage + cmake files + some updated modules
     )
 
     FetchContent_MakeAvailable(FreeImage)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.22)
 
 option(MV_UNITY_BUILD "Combine target source files into batches for faster compilation" OFF)
+option(MV_IML_USE_SYSTEM_FREEIMAGE "Use local freeimage installation instead of building it" OFF)
 
 # -----------------------------------------------------------------------------
 # ImageLoader Plugin
@@ -23,39 +24,44 @@ if(MSVC)
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
 endif(MSVC)
 
-include(FetchContent)
-
 # -----------------------------------------------------------------------------
 # Dependencies
 # -----------------------------------------------------------------------------
 find_package(Qt6 COMPONENTS Widgets WebEngineWidgets Concurrent REQUIRED)
 find_package(ManiVault COMPONENTS Core PointData ImageData CONFIG QUIET)
 
-FetchContent_Declare(
-    FreeImage
-    GIT_REPOSITORY https://github.com/biovault/FreeImage
-    GIT_TAG 4532197864740ae6dc8331f7d956c0b4dbd7029c        # version 3.19.0.1 
-)
+if(MV_IML_USE_SYSTEM_FREEIMAGE)
+    set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+    find_package(FreeImage REQUIRED)
+else()
+    include(FetchContent)
+    
+    FetchContent_Declare(
+        FreeImage
+        GIT_REPOSITORY https://github.com/biovault/FreeImage
+        GIT_TAG 4532197864740ae6dc8331f7d956c0b4dbd7029c        # version 3.19.0.1, freeimage + cmake files + some updated modules
+    )
 
-FetchContent_MakeAvailable(FreeImage)
+    FetchContent_MakeAvailable(FreeImage)
 
-get_target_property(FreeImageVersion FreeImageLib VERSION)
-message(STATUS "FreeImage Version: ${FreeImageVersion}")
+    get_target_property(FreeImageVersion FreeImageLib VERSION)
+    message(STATUS "FreeImage Version: ${FreeImageVersion}")
 
-set_target_properties(FreeImage FreeImageLib LibJPEG LibJXR LibOpenJPEG LibPNG LibRaw LibTIFF4 LibWebP OpenEXR ZLibFreeImage 
-    PROPERTIES 
-    FOLDER LoaderPlugins/Dependencies/ImageLoaderPlugin
-)
+    set_target_properties(FreeImage FreeImageLib LibJPEG LibJXR LibOpenJPEG LibPNG LibRaw LibTIFF4 LibWebP OpenEXR ZLibFreeImage 
+        PROPERTIES 
+        FOLDER LoaderPlugins/Dependencies/ImageLoaderPlugin
+    )
 
-# Do not build static library
-set_target_properties(FreeImageLib PROPERTIES EXCLUDE_FROM_ALL ON)
+    # Do not build static library
+    set_target_properties(FreeImageLib PROPERTIES EXCLUDE_FROM_ALL ON)
 
-# Remove /permissive- for OpenEXR and FreeImage
-if(MSVC)
-    target_compile_options(OpenEXR PRIVATE /permissive)
-    target_compile_options(FreeImage PRIVATE /permissive)
-    target_compile_options(FreeImageLib PRIVATE /permissive) # we don't need the static library, but just in case someone does build it
-endif(MSVC)
+    # Remove /permissive- for OpenEXR and FreeImage
+    if(MSVC)
+        target_compile_options(OpenEXR PRIVATE /permissive)
+        target_compile_options(FreeImage PRIVATE /permissive)
+        target_compile_options(FreeImageLib PRIVATE /permissive) # we don't need the static library, but just in case someone does build it
+    endif(MSVC)
+endif()
 
 # -----------------------------------------------------------------------------
 # Source files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,13 @@ set_target_properties(FreeImage FreeImageLib LibJPEG LibJXR LibOpenJPEG LibPNG L
 # Do not build static library
 set_target_properties(FreeImageLib PROPERTIES EXCLUDE_FROM_ALL ON)
 
+# Remove /permissive- for OpenEXR and FreeImage
+if(MSVC)
+    target_compile_options(OpenEXR PRIVATE /permissive)
+    target_compile_options(FreeImage PRIVATE /permissive)
+    target_compile_options(FreeImageLib PRIVATE /permissive) # we don't need the static library, but just in case someone does build it
+endif(MSVC)
+
 # -----------------------------------------------------------------------------
 # Source files
 # -----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ find_package(ManiVault COMPONENTS Core PointData ImageData CONFIG QUIET)
 FetchContent_Declare(
     FreeImage
     GIT_REPOSITORY https://github.com/biovault/FreeImage
-    GIT_TAG db0f4151dd45a7bf98b9dfe9bd81190b523076dd    # version 3.19.0 with cmake files
+    GIT_TAG 4532197864740ae6dc8331f7d956c0b4dbd7029c        # version 3.19.0.1 
 )
 
 FetchContent_MakeAvailable(FreeImage)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,13 +50,6 @@ set_target_properties(FreeImage FreeImageLib LibJPEG LibJXR LibOpenJPEG LibPNG L
 # Do not build static library
 set_target_properties(FreeImageLib PROPERTIES EXCLUDE_FROM_ALL ON)
 
-# Remove /permissive- for OpenEXR and FreeImage
-if(MSVC)
-    target_compile_options(OpenEXR PRIVATE /permissive)
-    target_compile_options(FreeImage PRIVATE /permissive)
-    target_compile_options(FreeImageLib PRIVATE /permissive) # we don't need the static library, but just in case someone does build it
-endif(MSVC)
-
 # -----------------------------------------------------------------------------
 # Source files
 # -----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ option(MV_UNITY_BUILD "Combine target source files into batches for faster compi
 # ImageLoader Plugin
 # -----------------------------------------------------------------------------
 set(PROJECT "ImageLoaderPlugin")
-PROJECT(${PROJECT})
+PROJECT(${PROJECT} C CXX)
 
 # -----------------------------------------------------------------------------
 # CMake Options

--- a/cmake/FindFreeImage.cmake
+++ b/cmake/FindFreeImage.cmake
@@ -1,0 +1,54 @@
+set(FREEIMAGE_INCLUDE_DIR_HINTS "" CACHE PATH "FreeImage include directory")
+set(FREEIMAGE_LIBRARY_DIR_HINTS "" CACHE PATH "FreeImage library directory")
+
+unset(FREEIMAGE_FOUND)
+
+if(TARGET FreeImage)
+    set(FREEIMAGE_FOUND TRUE)
+    message(STATUS "Found FreeImage")
+    message(STATUS "  Target : FreeImage")
+else()
+    list(APPEND FREEIMAGE_CHECK_INCLUDE_DIRS
+        ${FREEIMAGE_INCLUDE_DIR_HINTS}
+        /usr/include 
+        /usr/local/include 
+        /opt/homebrew/include
+    )
+
+    list(APPEND FREEIMAGE_CHECK_LIBRARY_DIRS
+        ${FREEIMAGE_LIBRARY_DIR_HINTS}
+        /usr/lib 
+        /usr/local/lib 
+        /opt/homebrew/lib
+    )
+
+    find_path(FreeImage_INCLUDE_DIRS
+        NAMES 
+        FreeImage.h
+        PATHS 
+        ${FREEIMAGE_CHECK_INCLUDE_DIRS})
+    )
+
+    find_library(FreeImage_LIBRARIES
+        NAMES 
+        freeimage
+        PATHS 
+        ${FREEIMAGE_CHECK_LIBRARY_DIRS})
+    )
+
+    if(FREEIMAGE_INCLUDE_DIRS AND FREEIMAGE_LIBRARIES)
+        set(FREEIMAGE_FOUND TRUE)
+
+        add_library(FreeImage INTERFACE IMPORTED)
+        target_include_directories(
+            FreeImage INTERFACE ${FREEIMAGE_INCLUDE_DIRS})
+        target_link_libraries(
+            FreeImage INTERFACE ${FREEIMAGE_LIBRARIES})
+
+        message(STATUS "Found FreeImage")
+        message(STATUS "  Includes : ${FREEIMAGE_INCLUDE_DIRS}")
+        message(STATUS "  Libraries : ${FREEIMAGE_LIBRARIES}")
+    else()
+         message(FATAL_ERROR "Could not find FreeImage")
+    endif()
+endif()


### PR DESCRIPTION
Fixes builds with newer AppleClang, specifically 16.3 and up by updating the FreeImage repo.

- [x] Update the FreeImage hash once https://github.com/biovault/FreeImage/pull/11 is merged to the master branch commit