### PR TITLE
Prevent overflow in memory consumption

### DIFF
--- a/src/ImageCollection.cpp
+++ b/src/ImageCollection.cpp
@@ -1613,10 +1613,10 @@ QVariant ImageCollection::getMemoryConsumption(const int& role) const
 {
     const auto noPoints = this->getNoPoints(Qt::EditRole).toInt();
     const auto noDimensions = this->getNoDimensions(Qt::EditRole).toInt();
-    const auto noElements = noPoints * noDimensions;
-    const auto noBytes = noElements * sizeof(float);
+    const size_t noElements = static_cast<size_t>(noPoints) * noDimensions;
+    const size_t noBytes = noElements * sizeof(float);
 
-    const auto memoryString = getNoBytesHumanReadable(static_cast<std::int32_t>(noBytes));
+    const auto memoryString = getNoBytesHumanReadable(noBytes);
 
     switch (role)
     {


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/da4e01c1-3a7b-4f5f-8457-3e8f00245290)

After:

![image](https://github.com/user-attachments/assets/697d5cf8-1bd7-4756-9fde-d32dfd788799)

Depends on https://github.com/ManiVaultStudio/core/pull/836