### PR TITLE
Use readme as help menu entry

### DIFF
--- a/src/ImageLoaderPlugin.cpp
+++ b/src/ImageLoaderPlugin.cpp
@@ -3,6 +3,8 @@
 
 #include <PointData/PointData.h>
 
+#include <widgets/MarkdownDialog.h>
+
 #include <QDebug>
 
 using namespace mv;
@@ -56,9 +58,31 @@ QModelIndexList ImageLoaderPlugin::getSelectedRows() const
 ImageLoaderPluginFactory::ImageLoaderPluginFactory()
 {
     setIconByName("images");
+
+    connect(&getPluginMetadata().getTriggerHelpAction(), &TriggerAction::triggered, this, [this]() -> void {
+        if (!getReadmeMarkdownUrl().isValid() || _helpMarkdownDialog.get())
+            return;
+
+        _helpMarkdownDialog = new util::MarkdownDialog(getReadmeMarkdownUrl());
+
+        _helpMarkdownDialog->setWindowTitle(QString("%1").arg(getKind()));
+        _helpMarkdownDialog->setAttribute(Qt::WA_DeleteOnClose);
+        _helpMarkdownDialog->setWindowModality(Qt::NonModal);
+        _helpMarkdownDialog->show();
+        });
 }
 
 LoaderPlugin* ImageLoaderPluginFactory::produce()
 {
     return new ImageLoaderPlugin(this);
+}
+
+QUrl ImageLoaderPluginFactory::getReadmeMarkdownUrl() const
+{
+    return QUrl("https://raw.githubusercontent.com/ManiVaultStudio/ImageLoaderPlugin/master/README.md");
+}
+
+QUrl ImageLoaderPluginFactory::getRepositoryUrl() const
+{
+    return QUrl("https://github.com/ManiVaultStudio/ImageLoaderPlugin");
 }

--- a/src/ImageLoaderPlugin.h
+++ b/src/ImageLoaderPlugin.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Common.h"
 #include "ImageCollectionScanner.h"
 #include "ImageCollectionsModel.h"
 #include "ConversionAction.h"
@@ -8,8 +7,15 @@
 #include <LoaderPlugin.h>
 #include <PluginFactory.h>
 
+#include <QPointer>
+#include <QUrl>
+
 using mv::plugin::LoaderPluginFactory;
 using mv::plugin::LoaderPlugin;
+
+namespace mv::util {
+    class MarkdownDialog;
+}
 
 /**
  * Image loader plugin class
@@ -65,9 +71,18 @@ public:
     /** Destructor */
     ~ImageLoaderPluginFactory() override {}
 
+    QUrl getReadmeMarkdownUrl() const override;
+
+    bool hasHelp() const override { return true; }
+
+    QUrl getRepositoryUrl() const override;
+
     /**
      * Produces the plugin
      * @return Pointer to the produced plugin
      */
     LoaderPlugin* produce() override;
+
+private:
+    QPointer<mv::util::MarkdownDialog>   _helpMarkdownDialog = {};
 };


### PR DESCRIPTION
Show the README of this repo has a markdown in the help menu, same as https://github.com/ManiVaultStudio/UMAP-Plugin/pull/11.

See [Plugin help menu entry](https://github.com/ManiVaultStudio/DeveloperWiki/wiki/Plugin-Structure#plugin-help-menu-entry) in the wiki.