### PR TITLE
Adjust install path on apple, fix FindFreeImage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,13 @@ if(MV_UNITY_BUILD)
     set_target_properties(${PROJECT} PROPERTIES UNITY_BUILD ON)
 endif()
 
+if(APPLE)
+    set_target_properties(${PROJECT} PROPERTIES
+        INSTALL_RPATH "@executable_path/../Frameworks"
+        INSTALL_RPATH_USE_LINK_PATH TRUE
+    )
+endif()
+
 # -----------------------------------------------------------------------------
 # Target library linking
 # -----------------------------------------------------------------------------

--- a/cmake/FindFreeImage.cmake
+++ b/cmake/FindFreeImage.cmake
@@ -36,18 +36,18 @@ else()
         ${FREEIMAGE_CHECK_LIBRARY_DIRS}
     )
 
-    if(FREEIMAGE_INCLUDE_DIRS AND FREEIMAGE_LIBRARIES)
+    if(FreeImage_INCLUDE_DIRS AND FreeImage_LIBRARIES)
         set(FREEIMAGE_FOUND TRUE)
 
-        add_library(FreeImage INTERFACE IMPORTED)
-        target_include_directories(
-            FreeImage INTERFACE ${FREEIMAGE_INCLUDE_DIRS})
-        target_link_libraries(
-            FreeImage INTERFACE ${FREEIMAGE_LIBRARIES})
+        add_library(FreeImage SHARED IMPORTED)
+        set_target_properties(FreeImage PROPERTIES
+            IMPORTED_LOCATION "${FreeImage_LIBRARIES}"
+            INTERFACE_INCLUDE_DIRECTORIES "${FreeImage_INCLUDE_DIRS}"
+        )
 
         message(STATUS "Found FreeImage")
-        message(STATUS "  Includes : ${FREEIMAGE_INCLUDE_DIRS}")
-        message(STATUS "  Libraries : ${FREEIMAGE_LIBRARIES}")
+        message(STATUS "  Includes : ${FreeImage_INCLUDE_DIRS}")
+        message(STATUS "  Libraries : ${FreeImage_LIBRARIES}")
     else()
          message(FATAL_ERROR "Could not find FreeImage")
     endif()

--- a/cmake/FindFreeImage.cmake
+++ b/cmake/FindFreeImage.cmake
@@ -26,14 +26,14 @@ else()
         NAMES 
         FreeImage.h
         PATHS 
-        ${FREEIMAGE_CHECK_INCLUDE_DIRS})
+        ${FREEIMAGE_CHECK_INCLUDE_DIRS}
     )
 
     find_library(FreeImage_LIBRARIES
         NAMES 
         freeimage
         PATHS 
-        ${FREEIMAGE_CHECK_LIBRARY_DIRS})
+        ${FREEIMAGE_CHECK_LIBRARY_DIRS}
     )
 
     if(FREEIMAGE_INCLUDE_DIRS AND FREEIMAGE_LIBRARIES)


### PR DESCRIPTION
- Set RPath for correctly for AppBundle build on Apple
- Fix FindFreeImage for using system-wide install of FreeImage