### PR TITLE
Fix enum end

### DIFF
--- a/src/ImageCollection.h
+++ b/src/ImageCollection.h
@@ -64,7 +64,7 @@ public: // Enumerations
         MirrorVertical,                 /** Whether to mirror the image and coordinates vertically */
 
         Start = Name,                   /** Column start */
-        End = Conversion                /** Column End */
+        End = MirrorVertical            /** Column End */
     };
 
 public: // Nested image class


### PR DESCRIPTION
Fixes a wrong UI heading:

https://github.com/ManiVaultStudio/ImageLoaderPlugin/pull/114 added a couple of entries to the `ImageCollection::Column` but did not adjust end `End` entry. That is referenced in `ImageCollection::Image::Column` for setting the first value. This let to the situation where this switch could never be reached:

https://github.com/ManiVaultStudio/ImageLoaderPlugin/blob/3962865b58e1777aa83e23fefd78bd93aee98888/src/ImageCollectionsModel.cpp#L548

Instead of using "Dimension name" a column heading in the loader dialog would show "Mirror vertically".