### PR TITLE
Update dependencies and fix warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,13 +30,13 @@ jobs:
     steps:
       - name: Checkout the source
         if: ${{ github.event_name != 'pull_request'}}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
             submodules: recursive
 
       - name: Checkout the source (pull_request version)
         if: ${{ github.event_name == 'pull_request'}}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
             ref: ${{ github.event.pull_request.head.ref }}
             submodules: recursive
@@ -52,7 +52,7 @@ jobs:
           python-version: "3.12"
 
       - name: Start ssh key agent
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.RULESSUPPORT_DEPLOY_KEY }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,12 +12,7 @@ PROJECT(${PROJECT} C CXX)
 # -----------------------------------------------------------------------------
 # CMake Options
 # -----------------------------------------------------------------------------
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTORCC ON)
-
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
@@ -152,12 +147,11 @@ target_include_directories(${PROJECT} PRIVATE "${ManiVault_INCLUDE_DIR}")
 # Target properties
 # -----------------------------------------------------------------------------
 target_compile_features(${PROJECT} PRIVATE cxx_std_20)
-
-target_compile_definitions(${PROJECT} PRIVATE DISABLE_PERF_MEASUREMENT)
  
-if(MV_UNITY_BUILD)
-    set_target_properties(${PROJECT} PROPERTIES UNITY_BUILD ON)
-endif()
+set_target_properties(${PROJECT} PROPERTIES 
+    AUTOMOC ON
+    UNITY_BUILD ${MV_UNITY_BUILD}
+)
 
 if(APPLE)
     set_target_properties(${PROJECT} PROPERTIES

--- a/src/Common.h
+++ b/src/Common.h
@@ -15,5 +15,6 @@ constexpr auto ult(E e) noexcept
 
 inline bool isColumnInModelIndexRange(const QModelIndex& topLeft, const QModelIndex& bottomRight, const std::uint32_t& column)
 {
-    return topLeft.column() <= column || bottomRight.column() >= column;
+    return static_cast<std::uint32_t>(topLeft.column()) <= column 
+    || static_cast<std::uint32_t>(bottomRight.column()) >= column;
 }

--- a/src/DatasetNameAction.cpp
+++ b/src/DatasetNameAction.cpp
@@ -6,7 +6,7 @@ DatasetNameAction::DatasetNameAction(QObject* parent, ImageLoaderPlugin& imageLo
     _imageLoaderPlugin(imageLoaderPlugin)
 {
     setEnabled(false);
-    setToolTip("Determines the dataset name in the HDPS data model");
+    setToolTip("Determines the dataset name in the ManiVault data model");
     setPlaceHolderString("Enter dataset name...");
 
     connect(this, &StringAction::stringChanged, this, &DatasetNameAction::updateRows);

--- a/src/ImageCollectionsAction.h
+++ b/src/ImageCollectionsAction.h
@@ -11,7 +11,6 @@
 #include <actions/WidgetAction.h>
 #include <actions/StringAction.h>
 #include <actions/OptionAction.h>
-#include <actions/DecimalAction.h>
 
 #include <QTreeView>
 

--- a/src/ImageCollectionsModel.h
+++ b/src/ImageCollectionsModel.h
@@ -76,7 +76,8 @@ public: // Filter model
 
             _filter = filter;
 
-            invalidateFilter();
+            beginFilterChange();
+            endFilterChange(QSortFilterProxyModel::Direction::Rows);
         }
 
     private:

--- a/src/ImageLoaderDialog.cpp
+++ b/src/ImageLoaderDialog.cpp
@@ -80,11 +80,11 @@ void ImageLoaderDialog::updateActions()
 
     if (selectedRows.isEmpty()) {
         _loadAction.setText("Load");
-        _loadAction.setToolTip("Load image datasets into HDPS");
+        _loadAction.setToolTip("Load image datasets into ManiVault");
     }
     else {
         _loadAction.setText(QString("Load %1").arg(QString::number(selectedRows.count())));
-        _loadAction.setToolTip(QString("Load %1 image datasets into HDPS").arg(QString::number(selectedRows.count())));
+        _loadAction.setToolTip(QString("Load %1 image datasets into ManiVault").arg(QString::number(selectedRows.count())));
     }
     
     _closeAfterLoadingAction.setEnabled(hasSelection);

--- a/src/ImageLoaderDialog.h
+++ b/src/ImageLoaderDialog.h
@@ -2,7 +2,6 @@
 
 #include "ScanAction.h"
 #include "ImageCollectionsAction.h"
-#include "ImagesAction.h"
 
 #include <actions/ToggleAction.h>
 #include <actions/TriggerAction.h>

--- a/src/ImageLoaderPlugin.h
+++ b/src/ImageLoaderPlugin.h
@@ -16,7 +16,7 @@ namespace mv::util {
 /**
  * Image loader plugin class
  *
- * This image loader plugin class provides functionality to load high-dimensional image data into HDPS
+ * This image loader plugin class provides functionality to load high-dimensional image data into ManiVault
  *
  * @author Thomas Kroes
  */

--- a/src/ImageLoaderPlugin.h
+++ b/src/ImageLoaderPlugin.h
@@ -5,13 +5,9 @@
 #include "ConversionAction.h"
 
 #include <LoaderPlugin.h>
-#include <PluginFactory.h>
 
 #include <QPointer>
 #include <QUrl>
-
-using mv::plugin::LoaderPluginFactory;
-using mv::plugin::LoaderPlugin;
 
 namespace mv::util {
     class MarkdownDialog;
@@ -24,7 +20,7 @@ namespace mv::util {
  *
  * @author Thomas Kroes
  */
-class ImageLoaderPlugin : public LoaderPlugin
+class ImageLoaderPlugin : public mv::plugin::LoaderPlugin
 {
 public:
     ImageLoaderPlugin(const mv::plugin::PluginFactory* factory);
@@ -57,7 +53,7 @@ private:
  * Image loader plugin factory class
  * A factory for creating image loader plugin instances
  */
-class ImageLoaderPluginFactory : public LoaderPluginFactory
+class ImageLoaderPluginFactory : public mv::plugin::LoaderPluginFactory
 {
     Q_INTERFACES(mv::plugin::LoaderPluginFactory mv::plugin::PluginFactory)
         Q_OBJECT
@@ -81,7 +77,7 @@ public:
      * Produces the plugin
      * @return Pointer to the produced plugin
      */
-    LoaderPlugin* produce() override;
+    mv::plugin::LoaderPlugin* produce() override;
 
 private:
     QPointer<mv::util::MarkdownDialog>   _helpMarkdownDialog = {};


### PR DESCRIPTION
- `QSortFilterProxyModel::invalidateFilter` is scheduled for deprecation in Qt 6.13, see https://doc.qt.io/qt-6/qsortfilterproxymodel.html#invalidateFilter
- Update some CI actions
- Simplify CMake: Set `AUTOMOC` specifically for target instead of globally